### PR TITLE
Listener support and cleanup

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ $app->register(Mlntn\Providers\LumenQueueServiceProvider::class);
 Set up a worker configuration:
 ```
     'worker_name' => [
-        'connection' => 'my_unique_name',
+        'connection' => 'my_unique_queue_connection_name',
         'queue'      => ['default'],
         'balance'    => 'auto',
         'processes'  => 16,
@@ -125,5 +125,5 @@ For more detailed information head over to https://github.com/illuminate/queue
 Specify the connection name used in `config/queue.php`
 
 ```
-php artisan queue:work my_unique_name
+php artisan queue:work my_unique_queue_connection_name
 ```

--- a/src/Queue/HorizonUniqueQueue.php
+++ b/src/Queue/HorizonUniqueQueue.php
@@ -45,7 +45,9 @@ class HorizonUniqueQueue extends RedisQueue
     protected function createObjectPayload($job,$queue)
     {
         return array_merge([
-            'uniqueIdentifier' => $job->getUniqueIdentifier(),
+            'uniqueIdentifier' => isset($job->class)
+                ? (new $job->class)->getUniqueIdentifier()
+                : $job->getUniqueIdentifier(),
         ], parent::createObjectPayload($job,$queue));
     }
 

--- a/src/Queue/RedisUniqueQueue.php
+++ b/src/Queue/RedisUniqueQueue.php
@@ -45,7 +45,9 @@ class RedisUniqueQueue extends RedisQueue
     protected function createObjectPayload($job,$queue)
     {
         return array_merge([
-            'uniqueIdentifier' => $job->getUniqueIdentifier(),
+            'uniqueIdentifier' => isset($job->class)
+                ? (new $job->class)->getUniqueIdentifier()
+                : $job->getUniqueIdentifier(),
         ], parent::createObjectPayload($job,$queue));
     }
 


### PR DESCRIPTION
The event isn't the place where the uniqueness should be handled, that should be handled at the listener because you can have multiple listeners on an event.